### PR TITLE
correct "Vim script"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Global Options
        java               : Java        (java.net.HttpURLConnection)
        objc, objc.session : Objective-C (NSURLSession)
        objc.connection    :             (NSURLConnection)
-       vim                : Vim Script  (WebAPI-vim)
+       vim                : Vim script  (WebAPI-vim)
 
 Supported cURL Options
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/httpgen.go
+++ b/httpgen.go
@@ -28,7 +28,7 @@ This program supports one of the following targets:
 * objc, objc.session : Objective-C (NSURLSession)
 * objc.connection    : Objective-C (NSURLConnection)
 * php                : PHP         (fopen)
-* vim                : Vim Script  (webapi-vim)`, target)
+* vim                : Vim script  (webapi-vim)`, target)
 }
 
 func main() {


### PR DESCRIPTION
**Vim scirpt** is proper spelling.

たまにマサカリが飛んできます。
