### PR TITLE
add writer.Close() method.

### DIFF
--- a/client/golang/sourcewriter.go
+++ b/client/golang/sourcewriter.go
@@ -170,6 +170,7 @@ func (self *GoGenerator) SetFormForBody() {
 	for _, data := range self.Options.ProcessedData {
 		buffer.WriteString(FormString(self, &data))
 	}
+	buffer.WriteString("writer.Close()\n")
 	self.Data = buffer.String()
 }
 


### PR DESCRIPTION
日本語ですみません。

`-F` オプションを伴った curl コマンドを Go 言語に変換したところ，所定の結果が得られませんでした。

調べてみたところ，出力される Go のコードの form データをセットしている部分でバッファが flush されていないため，サーバ側に上手くデータが渡っていないようです。バッファにデータを flush するコードを追加することで上手く動きました。

よろしければこのリクエストを参考にして下さい。

参考: [Git.io 短縮 URL を golang コードで取得してみる - Qiita](http://qiita.com/spiegel-im-spiegel/items/042751d98e315e4e3382)
